### PR TITLE
AfterViewInit upgrade #27

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChild} from "@angular/core";
+import {Component, OnInit, ViewChild, AfterViewInit} from "@angular/core";
 import {DashboardComponent, WidgetComponent} from "../dist";
 import {MyWidgetComponent} from "./my-widget/my-widget.component";
 
@@ -10,7 +10,7 @@ import {MyWidgetComponent} from "./my-widget/my-widget.component";
     '(window:resize)': '_onResize($event)',
   }
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
   title = 'app works!';
   @ViewChild(DashboardComponent) dashboard: DashboardComponent;
   widgetsSize: number[] = [300, 150];
@@ -22,6 +22,13 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this._onResize(null)
+  }
+
+  /**
+   * On Windows based machines this ensures that the resize is valid after the dom content has been loaded.
+   */
+  ngAfterViewInit(): void {
+    this._onResize(null);
   }
 
   private _onResize(event: any) {

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -21,14 +21,15 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
-    this._onResize(null)
   }
 
   /**
    * On Windows based machines this ensures that the resize is valid after the dom content has been loaded.
    */
   ngAfterViewInit(): void {
-    this._onResize(null);
+    setTimeout(() => {
+      this._onResize(null);
+    })
   }
 
   private _onResize(event: any) {


### PR DESCRIPTION
This Fixes bug #27 It's a short fix but it may be better to handle this directly from the native resize function or you could probably just move your entire OnInit inital resize call to an afterview init so the resize has vision of the DOM elements.